### PR TITLE
Setup Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: python -m modmail

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: python -m modmail
+web: python -m modmail

--- a/modmail/config.py
+++ b/modmail/config.py
@@ -64,7 +64,10 @@ def toml_user_config_source(settings: PydanticBaseSettings) -> Dict[str, Any]:
     Here we happen to choose to use the `env_file_encoding` from Config
     when reading `config-default.toml`
     """
-    return dict(**toml.load(USER_CONFIG_PATH))
+    if USER_CONFIG_PATH:
+        return dict(**toml.load(USER_CONFIG_PATH))
+    else:
+        return dict()
 
 
 class BaseSettings(PydanticBaseSettings):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ lint = "pre-commit run --all-files"
 precommit = "pre-commit install"
 black = "black --check ."
 flake8 = "python -m flake8"
+export = "poetry export -o requirements.txt --without-hashes"
 
 [tool.black]
 line-length = 99

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+aiodns==3.0.0; python_version >= "3.6" and python_full_version >= "3.5.3"
+aiohttp==3.7.4.post0; python_version >= "3.6"
+async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
+attrs==21.2.0; python_full_version >= "3.5.3" and python_version >= "3.6"
+brotlipy==0.7.0; python_version >= "3.6" and python_full_version >= "3.5.3"
+cchardet==2.1.7; python_version >= "3.6" and python_full_version >= "3.5.3"
+cffi==1.14.5; python_version >= "3.6"
+chardet==4.0.0; python_full_version >= "3.5.3" and python_version >= "3.6"
+colorama==0.4.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+coloredlogs==15.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+discord.py==1.6.0; python_full_version >= "3.5.3"
+humanfriendly==9.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+idna==3.1; python_version >= "3.6"
+multidict==5.1.0; python_version >= "3.6" and python_full_version >= "3.5.3"
+pycares==4.0.0; python_version >= "3.6"
+pycparser==2.20; python_version >= "3.6" and python_full_version < "3.0.0" or python_version >= "3.6" and python_full_version >= "3.4.0"
+pydantic==1.8.2; python_full_version >= "3.6.1"
+pyreadline==2.1; python_version >= "2.7" and python_full_version < "3.0.0" and sys_platform == "win32" or python_full_version >= "3.5.0" and sys_platform == "win32"
+python-dotenv==0.17.1
+toml==0.10.2; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
+typing-extensions==3.10.0.0; python_version >= "3.6" and python_full_version >= "3.6.1"
+yarl==1.6.3; python_version >= "3.6" and python_full_version >= "3.5.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# Do not manually edit.
+# Generate with "poetry run task export"
+
 aiodns==3.0.0; python_version >= "3.6" and python_full_version >= "3.5.3"
 aiohttp==3.7.4.post0; python_version >= "3.6"
 async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"


### PR DESCRIPTION
Add procfile to enable deploying on railway.

Due to limitations with buildpacks, there is a requirements.txt file added for the sole purpose of adding dependencies on railway/heroku.

This pr has not been tested for deploying on heroku, which will come at a later date.