### PR TITLE
Clean up logging file

### DIFF
--- a/modmail/__init__.py
+++ b/modmail/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import logging.handlers
-import os
 from pathlib import Path
 
 import coloredlogs
@@ -13,35 +12,14 @@ logging.addLevelName(logging.TRACE, "TRACE")
 logging.addLevelName(logging.NOTICE, "NOTICE")
 
 LOG_LEVEL = 20
-
+fmt = "%(asctime)s %(levelname)10s %(name)15s - [%(lineno)5d]: %(message)s"
+datefmt = "%Y/%m/%d %H:%M:%S"
 
 logging.setLoggerClass(ModmailLogger)
 
 # Set up file logging
-log_dir = Path("./logs")
-log_file = log_dir / "bot.log"
-os.makedirs(log_dir, exist_ok=True)
-
-# Default formats
-fmt = "%(asctime)s %(levelname)s %(name)s - [%(lineno)d]: %(message)s"
-datefmt = "%Y/%m/%d %H:%M:%S"
-
-colored_formatter = coloredlogs.ColoredFormatter(
-    fmt=fmt,
-    datefmt=datefmt,
-)
-formatter = logging.Formatter(
-    fmt=fmt,
-    datefmt=datefmt,
-)
-
-
-# Console handler prints to terminal
-# console_handler = logging.StreamHandler()
-
-# console_handler.setFormatter(colored_formatter)
-# console_handler.setLevel(logging.TRACE)
-
+log_file = Path("./logs") / "bot.log"
+log_file.parent.mkdir(parents=True, exist_ok=True)
 
 # file handler
 file_handler = logging.handlers.RotatingFileHandler(
@@ -50,14 +28,15 @@ file_handler = logging.handlers.RotatingFileHandler(
     backupCount=5,
     encoding="utf-8",
 )
-file_handler.setFormatter(formatter)
+
+file_handler.setFormatter(
+    logging.Formatter(
+        fmt=fmt,
+        datefmt=datefmt,
+    )
+)
+
 file_handler.setLevel(logging.TRACE)
-
-
-# Silence irrelevant loggers
-logging.getLogger("discord").setLevel(logging.WARNING)
-logging.getLogger("websockets").setLevel(logging.ERROR)
-logging.getLogger("asyncio").setLevel(logging.INFO)
 
 coloredlogs.install(
     level=LOG_LEVEL,
@@ -65,9 +44,14 @@ coloredlogs.install(
     datefmt=datefmt,
 )
 
+# Create root logger
 root: ModmailLogger = logging.getLogger()
 root.addHandler(file_handler)
-# Set back to the default of INFO even if asyncio's debug mode is enabled.
+
+# Silence irrelevant loggers
+logging.getLogger("discord").setLevel(logging.WARNING)
+logging.getLogger("websockets").setLevel(logging.ERROR)
+# Set asyncio logging back to the default of INFO even if asyncio's debug mode is enabled.
 logging.getLogger("asyncio").setLevel(logging.INFO)
 
 root.debug("Logging initialization complete")

--- a/modmail/__init__.py
+++ b/modmail/__init__.py
@@ -18,7 +18,7 @@ datefmt = "%Y/%m/%d %H:%M:%S"
 logging.setLoggerClass(ModmailLogger)
 
 # Set up file logging
-log_file = Path("./logs") / "bot.log"
+log_file = Path("./logs/bot.log")
 log_file.parent.mkdir(parents=True, exist_ok=True)
 
 # file handler


### PR DESCRIPTION
- stick formats up top for easy editing
- strip the colored_formatter as coloredlogs INSTALL does that for us
- remove commented code
- move logger silencing below instantiation so there's no need to ever do one twice
- utilize pathlib methods for making logging dir, no need for os after it's removed


Closes #40 