### PR TITLE
update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.2
+    rev: 5.9.3
     hooks:
       - id: isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,16 +35,12 @@ repos:
     hooks:
       - id: python-check-blanket-noqa
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: local
     hooks:
       - id: flake8
-        additional_dependencies:
-          - flake8-annotations~=2.6.2
-          - flake8-bandit~=2.1.2
-          - flake8-bugbear~=21.4.3
-          - flake8-docstrings~=1.6.0
-          - flake8-isort~=4.0.0
-          - flake8-string-format~=0.3.0
-          - flake8-tidy-imports~=4.3.0
-          - flake8-todo~=0.7
+        name: flake8
+        description: '`flake8` is a command-line utility for enforcing style consistency across Python projects.'
+        entry: flake8
+        language: python
+        types: [python]
+        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,10 +30,6 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.5.1
-    hooks:
-      - id: python-check-blanket-noqa
 
   - repo: local
     hooks:


### PR DESCRIPTION
using the PyCQA flake8 hook was not catching all of the errors as
notated in tox.ini
In addition, because we have local flake8 extensions, it makes more
sense to not duplicate their config in multiple locations.
