### PR TITLE
ci: add python 3.10 to workflows

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.8', '3.9','3.10.0rc1 - 3.10']
+        python_version: ['3.8', '3.9','3.10.0-rc.1 - 3.10']
     env:
       PYTHON_VERSION: ${{ matrix.python_version }}
     steps:
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.8', '3.9','3.10.0rc1 - 3.10']
+        python_version: ['3.8', '3.9','3.10.0-rc.1 - 3.10']
     env:
       PYTHON_VERSION: ${{ matrix.python_version }}
     steps:

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.8', '3.9','3.10.0rc1 - 3.10']
     env:
       PYTHON_VERSION: ${{ matrix.python_version }}
     steps:
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.8', '3.9']
+        python_version: ['3.8', '3.9','3.10.0rc1 - 3.10']
     env:
       PYTHON_VERSION: ${{ matrix.python_version }}
     steps:


### PR DESCRIPTION
With python 3.10 set to release in a few months, it would be a good idea to ensure code works on it while developing it.

If it breaks at any point, that's a good sign of a regression.