### PR TITLE
chore: make codecov support coverage for the entire modmail folder

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,7 +13,7 @@ coverage:
       default: false
       bot:
         paths:
-          - modmail
+          - 'modmail/'
         # basic
         target: auto
         threshold: 5%


### PR DESCRIPTION
since the line was missing a `/` codecov was only checking the modmail
file iteself, which doesn't exist, so no coverage was reported.
