### PR TITLE
fix: change flake8 instance to always run in the poetry venv in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
       - id: flake8
         name: flake8
         description: '`flake8` is a command-line utility for enforcing style consistency across Python projects.'
-        entry: flake8
+        entry: poetry run flake8
         language: python
         types: [python]
         require_serial: true


### PR DESCRIPTION
fixes problem of not being in the venv when running git commit
