### PR TITLE
fix: paginator can now not use an embed

### DIFF
--- a/modmail/utils/pagination.py
+++ b/modmail/utils/pagination.py
@@ -62,7 +62,7 @@ class ButtonPaginator(ui.View, DpyPaginator):
         contents: Union[List[str], str],
         /,
         source_message: Optional[discord.Message] = None,
-        embed: Optional[Embed] = _AUTOGENERATE,
+        embed: Union[Embed, bool, None] = _AUTOGENERATE,
         timeout: float = 180,
         *,
         footer_text: str = None,
@@ -90,9 +90,11 @@ class ButtonPaginator(ui.View, DpyPaginator):
         self.suffix = suffix
         self.max_size = max_size
         self.linesep = linesep
-        if embed is _AUTOGENERATE:
+        if embed is _AUTOGENERATE or embed is True:
             self.embed = Embed()
         else:
+            if embed is False:
+                embed = None
             self.embed = embed
 
         # used if embed is None

--- a/modmail/utils/pagination.py
+++ b/modmail/utils/pagination.py
@@ -31,9 +31,12 @@ FORWARD_LABEL = "  \u276f  "  # >
 JUMP_LAST_LABEL = " \u276f\u276f "  # >>
 STOP_PAGINATE_EMOJI = "\u274c"  # [:x:] This is an emoji, which is treated differently from the above
 
-logger: ModmailLogger = logging.getLogger(__name__)
+NO_EMBED_FOOTER_BUMP = 15
 
 _AUTOGENERATE = object()
+
+
+logger: ModmailLogger = logging.getLogger(__name__)
 
 
 class ButtonPaginator(ui.View, DpyPaginator):
@@ -78,6 +81,8 @@ class ButtonPaginator(ui.View, DpyPaginator):
         If source message is provided and only_users is NOT provided, the paginator will respond
             to the author of the source message. To override this, pass an empty list to `only_users`.
 
+        By default, an embed is created. However, a custom embed can
+        be passed, or None can be passed to not use an embed.
         """
         self.index = 0
         self._pages: List[str] = []
@@ -92,11 +97,11 @@ class ButtonPaginator(ui.View, DpyPaginator):
 
         # used if embed is None
         self.content = ""
-        if embed is None:
+        if self.embed is None:
             self.title = title
             # need to set the max_size down a few to be able to set a "footer"
             # page indicator is "page xx of xx"
-            self.max_size -= 15
+            self.max_size -= NO_EMBED_FOOTER_BUMP + len(self.title or "")
             if self.title is not None:
                 self.max_size -= len(title)
             if footer_text is not None:

--- a/modmail/utils/pagination.py
+++ b/modmail/utils/pagination.py
@@ -92,11 +92,7 @@ class ButtonPaginator(ui.View, DpyPaginator):
 
         # used if embed is None
         self.content = ""
-        if embed is not None:
-            if title:
-                raise TypeError("Cannot set title if embed is None.")
-            self.title = None
-        else:
+        if embed is None:
             self.title = title
             # need to set the max_size down a few to be able to set a "footer"
             # page indicator is "page xx of xx"
@@ -301,7 +297,6 @@ class ButtonPaginator(ui.View, DpyPaginator):
         if self.embed:
             await interaction.message.edit(embed=self.embed, view=self)
         else:
-            print(len(self.content))
             await interaction.message.edit(content=self.content, view=self)
 
     @ui.button(label=JUMP_FIRST_LABEL, custom_id="pag_jump_first", style=ButtonStyle.primary)

--- a/modmail/utils/pagination.py
+++ b/modmail/utils/pagination.py
@@ -252,9 +252,11 @@ class ButtonPaginator(ui.View, DpyPaginator):
         """
         # update the footer
         page_indicator = f"Page {self.index+1}/{len(self._pages)}"
-        footer_text = (
-            f"{self.footer_text} ({page_indicator})" if self.footer_text is not None else page_indicator
-        )
+        if self.footer_text:
+            footer_text = f"{self.footer_text} ({page_indicator})"
+        else:
+            footer_text = page_indicator
+
         if self.embed is None:
             self.content = (self.title or "") + "\n"
             self.content += self._pages[self.index]

--- a/modmail/utils/pagination.py
+++ b/modmail/utils/pagination.py
@@ -230,18 +230,6 @@ class ButtonPaginator(ui.View, DpyPaginator):
         )
         return False
 
-    def get_footer(self) -> Optional[str]:
-        """Returns the footer text."""
-        if self.embed is None:
-            self.content = self._pages[self.index]
-            return None
-        self.embed.description = self._pages[self.index]
-        page_indicator = f"Page {self.index+1}/{len(self._pages)}"
-        footer_txt = (
-            f"{self.footer_text} ({page_indicator})" if self.footer_text is not None else page_indicator
-        )
-        return footer_txt
-
     def update_states(self) -> None:
         """
         Disable specific components depending on paginator page and length.
@@ -251,9 +239,18 @@ class ButtonPaginator(ui.View, DpyPaginator):
         if the paginator is on the last page, the jump last/move forward buttons will be disabled.
         """
         # update the footer
-        text = self.get_footer()
-        if self.embed:
-            self.embed.set_footer(text=text)
+        if self.embed is None:
+            self.content = self._pages[self.index]
+        else:
+            self.embed.description = self._pages[self.index]
+            page_indicator = f"Page {self.index+1}/{len(self._pages)}"
+            self.embed.set_footer(
+                text=(
+                    f"{self.footer_text} ({page_indicator})"
+                    if self.footer_text is not None
+                    else page_indicator
+                )
+            )
 
         # determine if the jump buttons should be enabled
         more_than_two_pages = len(self._pages) > 2

--- a/tests/modmail/utils/test_pagination.py
+++ b/tests/modmail/utils/test_pagination.py
@@ -1,5 +1,3 @@
-from typing import List, Union
-
 import pytest
 
 from modmail.utils.pagination import ButtonPaginator
@@ -11,29 +9,3 @@ async def test_paginator_init() -> None:
     content = ["content"]
     paginator = ButtonPaginator(content, prefix="", suffix="", linesep="")
     assert paginator.pages == content
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "content, footer_text",
-    [
-        (["5"], "Snap, crackle, pop"),
-        (["Earthly"], "world"),
-        ("There are no plugins installed.", None),
-    ],
-)
-async def test_paginator_footer(content: Union[str, List[str]], footer_text: str) -> None:
-    """Test the paginator footer matches what is passed."""
-    pag = ButtonPaginator(content, footer_text=footer_text)
-    print("index:", pag.index)
-    print("page len: ", len(pag.pages))
-    assert footer_text == pag.footer_text
-    if isinstance(content, str):
-        content = [content]
-
-    if footer_text is not None:
-        assert pag.get_footer().endswith(f"{len(content)})")
-        assert pag.get_footer().startswith(footer_text)
-
-    else:
-        assert pag.get_footer().endswith(f"{len(content)}")

--- a/tests/modmail/utils/test_pagination.py
+++ b/tests/modmail/utils/test_pagination.py
@@ -27,11 +27,10 @@ async def test_paginator_footer(content: Union[str, List[str]], footer_text: str
     pag = ButtonPaginator(content, footer_text=footer_text)
     print("index:", pag.index)
     print("page len: ", len(pag.pages))
-    assert pag.footer_text == footer_text
+    assert footer_text == pag.footer_text
     if isinstance(content, str):
         content = [content]
 
-    print(pag.get_footer())
     if footer_text is not None:
         assert pag.get_footer().endswith(f"{len(content)})")
         assert pag.get_footer().startswith(footer_text)


### PR DESCRIPTION
The paginator now will not always use an embed. This allows non-embedded pagination since embeds are restricted to a maximum width which we cannot control, but codeblocks are restrained to the width of the screen.