### PR TITLE
fix: use the post_cov-server event properly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,6 @@ lint = { cmd = "pre-commit run --all-files", help = "Checks all files for CI err
 # Testing
 codecov-validate = { cmd = "curl --data-binary @.codecov.yml https://codecov.io/validate", help = "Validate `.codecov.yml` with their api." }
 cov-server = { cmd = "coverage html", help = "Start an http.server for viewing coverage data." }
-post-cov-server = "python -m http.server 8012 --bind 127.0.0.1 --directory htmlcov"
+post_cov-server = "python -m http.server 8012 --bind 127.0.0.1 --directory htmlcov"
 report = { cmd = "coverage report", help = "Show coverage report from previously run tests." }
 test = { cmd = "pytest -n auto --dist loadfile", help = "Runs tests and save results to a coverage report" }


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->

Fix a typo in the pyproject.toml file which causes taskipy to not recognise the post task hook properly.

As documented, needs to be a `_` rather than a `-`

https://github.com/illBeRoy/taskipy#post-task-hook