### PR TITLE
Update embed patch

### DIFF
--- a/modmail/utils/embeds.py
+++ b/modmail/utils/embeds.py
@@ -67,7 +67,7 @@ def __init__(self: discord.Embed, description: str = None, **kwargs):  # noqa: N
         self.set_author(
             name=author_name if author_name is not None else author.name,
             url=author_url,
-            icon_url=author_icon or (str(author.avatar_url) if author else EmptyEmbed),
+            icon_url=author_icon or (str(author.display_avatar.url) if author else EmptyEmbed),
         )
 
     fields: List[Union[Tuple[str, str], Tuple[str, str, bool]]] = kwargs.pop("fields", [])


### PR DESCRIPTION
Now supports:
- passing None for color to make the color match the embed background
- passing content and description at the same time is handled better
- author field now supports users, members, and strings to just specify a name
- handle when an author doesn't have an avatar url
