### PR TITLE
fix: only import bot when type checking modmail.utils.cogs

### DIFF
--- a/modmail/utils/cogs.py
+++ b/modmail/utils/cogs.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
 from enum import IntEnum, auto
+from typing import TYPE_CHECKING
 
 from discord.ext import commands
 
-import modmail.bot
+
+if TYPE_CHECKING:  # pragma: nocover
+    import modmail.bot
 
 
 class BitwiseAutoEnum(IntEnum):


### PR DESCRIPTION
was causing a recursive error on tests when this was imported

## Relevant Issues

<!--
We highly recommend linking to an issue that has been approved by a maintainer, or making one yourself before opening a PR. Otherwise it may not be clear why a chance is necessary or you might do work that we had already decided against implementing, leading to wasted time and effort.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->

## Description

<!-- Describe what changes you made, and how you've implemented them. -->
