### PR TITLE
ci: checkout the actual ref instead of github's merge commit

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -30,6 +30,7 @@ env:
   POETRY_CACHE_DIR: ${{ github.workspace }}/.cache/py-user-base
   PYTHONUSERBASE: ${{ github.workspace }}/.cache/py-user-base
   PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit-cache
+  GIT_REF: ${{ github.head_ref }}
 
 jobs:
   lint:
@@ -47,6 +48,10 @@ jobs:
       # Checks out the repository in the current folder.
       - name: Checks out repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          ref: ${{ env.GIT_REF }}
+
 
       # Set up the right version of Python
       - name: Set up Python ${{ env.PYTHON_VERSION }}
@@ -128,6 +133,9 @@ jobs:
       # Checks out the repository in the current folder.
       - name: Checks out repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          ref: ${{ env.GIT_REF }}
 
       # Set up the right version of Python
       - name: Set up Python ${{ env.PYTHON_VERSION }}


### PR DESCRIPTION
Github makes a merge commit for any pull requests.
This checks back out our custom branch for linting and testing.
This does means that we lose the benefits of being able to see what
would happen if we merged with our default branch, but the problems
of our custom pre-commit hooks getting different output, and different
installed dependencies from what is on the branch dependending on how
up-to-date our branches are, is a problem that I would rather not have.
