### PR TITLE
tests: mock aiohttp responses and fix windows

### DIFF
--- a/modmail/__init__.py
+++ b/modmail/__init__.py
@@ -1,11 +1,17 @@
+import asyncio
 import logging
 import logging.handlers
+import os
 from pathlib import Path
 
 import coloredlogs
 
 from modmail.log import ModmailLogger
 
+
+# On Windows, the selector event loop is required for aiodns.
+if os.name == "nt":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 logging.TRACE = 5
 logging.NOTICE = 25

--- a/modmail/__init__.py
+++ b/modmail/__init__.py
@@ -9,7 +9,7 @@ import coloredlogs
 from modmail.log import ModmailLogger
 
 
-# on windows aiodns's asyncio support relies on APIs like add_reader (which aiodns uses)
+# On windows aiodns's asyncio support relies on APIs like add_reader (which aiodns uses)
 # are not guaranteed to be available, and in particular are not available when using the
 # ProactorEventLoop on Windows, this method is only supported with Windows SelectorEventLoop
 if os.name == "nt":

--- a/modmail/__init__.py
+++ b/modmail/__init__.py
@@ -9,7 +9,9 @@ import coloredlogs
 from modmail.log import ModmailLogger
 
 
-# On Windows, the selector event loop is required for aiodns.
+# on windows aiodns's asyncio support relies on APIs like add_reader (which aiodns uses)
+# are not guaranteed to be available, and in particular are not available when using the
+# ProactorEventLoop on Windows, this method is only supported with Windows SelectorEventLoop
 if os.name == "nt":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 

--- a/modmail/bot.py
+++ b/modmail/bot.py
@@ -1,12 +1,12 @@
 import asyncio
 import logging
 import signal
+import socket
 import typing as t
-from typing import Any
 
+import aiohttp
 import arrow
 import discord
-from aiohttp import ClientSession
 from discord import Activity, AllowedMentions, Intents
 from discord.client import _cleanup_loop
 from discord.ext import commands
@@ -41,8 +41,11 @@ class ModmailBot(commands.Bot):
     def __init__(self, **kwargs):
         self.config = CONFIG
         self.start_time: t.Optional[arrow.Arrow] = None  # arrow.utcnow()
-        self.http_session: t.Optional[ClientSession] = None
+        self.http_session: t.Optional[aiohttp.ClientSession] = None
         self.dispatcher = Dispatcher()
+
+        self._connector = None
+        self._resolver = None
 
         status = discord.Status.online
         activity = Activity(type=discord.ActivityType.listening, name="users dming me!")
@@ -65,6 +68,24 @@ class ModmailBot(commands.Bot):
             **kwargs,
         )
 
+    async def create_connectors(self, *args, **kwargs) -> None:
+        """Re-create the connector and set up sessions before logging into Discord."""
+        # Use asyncio for DNS resolution instead of threads so threads aren't spammed.
+        self._resolver = aiohttp.AsyncResolver()
+
+        # Use AF_INET as its socket family to prevent HTTPS related problems both locally
+        # and in production.
+        self._connector = aiohttp.TCPConnector(
+            resolver=self._resolver,
+            family=socket.AF_INET,
+        )
+
+        # Client.login() will call HTTPClient.static_login() which will create a session using
+        # this connector attribute.
+        self.http.connector = self._connector
+
+        self.http_session = aiohttp.ClientSession(connector=self._connector)
+
     async def start(self, token: str, reconnect: bool = True) -> None:
         """
         Start the bot.
@@ -74,8 +95,8 @@ class ModmailBot(commands.Bot):
         """
         try:
             # create the aiohttp session
-            self.http_session = ClientSession(loop=self.loop)
-            self.logger.trace("Created ClientSession.")
+            await self.create_connectors()
+            self.logger.trace("Created aiohttp.ClientSession.")
             # set start time to when we started the bot.
             # This is now, since we're about to connect to the gateway.
             # This should also be before we load any extensions, since if they have a load time, it should
@@ -122,7 +143,7 @@ class ModmailBot(commands.Bot):
         except NotImplementedError:
             pass
 
-        def stop_loop_on_completion(f: Any) -> None:
+        def stop_loop_on_completion(f: t.Any) -> None:
             loop.stop()
 
         future = asyncio.ensure_future(self.start(*args, **kwargs), loop=loop)
@@ -164,10 +185,16 @@ class ModmailBot(commands.Bot):
             except Exception:
                 self.logger.error(f"Exception occured while removing cog {cog.name}", exc_info=True)
 
+        await super().close()
+
         if self.http_session:
             await self.http_session.close()
 
-        await super().close()
+        if self._connector:
+            await self._connector.close()
+
+        if self._resolver:
+            await self._resolver.close()
 
     def load_extensions(self) -> None:
         """Load all enabled extensions."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,6 +32,17 @@ yarl = ">=1.0,<2.0"
 speedups = ["aiodns", "brotlipy", "cchardet"]
 
 [[package]]
+name = "aioresponses"
+version = "0.7.2"
+description = "Mock out requests made by ClientSession from aiohttp package"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+aiohttp = ">=2.0.0,<4.0.0"
+
+[[package]]
 name = "arrow"
 version = "1.1.1"
 description = "Better dates & times for Python"
@@ -1218,7 +1229,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "1086984557d7a4f7503e1f68d7a3a5662d2960998fec490144a3debdcc259256"
+content-hash = "0d2af2b4ba03d4d2292cd59fdb9aaa33b32b49d79f130a2f6d4419d7903c6fbc"
 
 [metadata.files]
 aiodns = [
@@ -1263,6 +1274,10 @@ aiohttp = [
     {file = "aiohttp-3.7.4.post0-cp39-cp39-win32.whl", hash = "sha256:932bb1ea39a54e9ea27fc9232163059a0b8855256f4052e776357ad9add6f1c9"},
     {file = "aiohttp-3.7.4.post0-cp39-cp39-win_amd64.whl", hash = "sha256:02f46fc0e3c5ac58b80d4d56eb0a7c7d97fcef69ace9326289fb9f1955e65cfe"},
     {file = "aiohttp-3.7.4.post0.tar.gz", hash = "sha256:493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf"},
+]
+aioresponses = [
+    {file = "aioresponses-0.7.2-py2.py3-none-any.whl", hash = "sha256:2f8ff624543066eb465b0238de68d29231e8488f41dc4b5a9dae190982cdae50"},
+    {file = "aioresponses-0.7.2.tar.gz", hash = "sha256:82e495d118b74896aa5b4d47e17effb5e2cc783e510ae395ceade5e87cabe89a"},
 ]
 arrow = [
     {file = "arrow-1.1.1-py3-none-any.whl", hash = "sha256:77a60a4db5766d900a2085ce9074c5c7b8e2c99afeaa98ad627637ff6f292510"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ flake8-todo = "~=0.7"
 isort = "^5.9.2"
 pep8-naming = "~=0.11"
 # testing
+aioresponses = "^0.7.2"
 coverage = { extras = ["toml"], version = "^6.0.2" }
 coveralls = "^3.3.1"
 pytest = "^6.2.4"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,23 @@
 import aiohttp
+import aioresponses
 import pytest
 
 
 @pytest.fixture
+def aioresponse():
+    """Fixture to mock aiohttp responses."""
+    with aioresponses.aioresponses() as aioresponse:
+        yield aioresponse
+
+
+@pytest.fixture
 @pytest.mark.asyncio
-async def http_session() -> aiohttp.ClientSession:
-    """Fixture function for a aiohttp.ClientSession."""
+async def http_session(aioresponse) -> aiohttp.ClientSession:
+    """
+    Fixture function for a aiohttp.ClientSession.
+
+    Requests fixture aioresponse to ensure that all client sessions do not make actual requests.
+    """
     resolver = aiohttp.AsyncResolver()
     connector = aiohttp.TCPConnector(resolver=resolver)
     client_session = aiohttp.ClientSession(connector=connector)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,17 @@
+import aiohttp
 import pytest
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def http_session() -> aiohttp.ClientSession:
+    """Fixture function for a aiohttp.ClientSession."""
+    resolver = aiohttp.AsyncResolver()
+    connector = aiohttp.TCPConnector(resolver=resolver)
+    client_session = aiohttp.ClientSession(connector=connector)
+
+    yield client_session
+
+    await client_session.close()
+    await connector.close()
+    await resolver.close()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import aiohttp
+import pytest
+
+
+if TYPE_CHECKING:
+    import aioresponses
+
+
+class TestSessionFixture:
+    """Grouping for aiohttp.ClientSession fixture tests."""
+
+    @pytest.mark.asyncio
+    async def test_session_fixture_no_requests(self, http_session: aiohttp.ClientSession):
+        """
+        Test all requests fail.
+
+        This means that aioresponses is being requested by the http_session fixture.
+        """
+        url = "https://github.com/"
+
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await http_session.get(url)
+
+    @pytest.mark.asyncio
+    async def test_session_fixture_mock_requests(
+        self, aioresponse: aioresponses.aioresponses, http_session: aiohttp.ClientSession
+    ):
+        """
+        Test all requests fail.
+
+        This means that aioresponses is being requested by the http_session fixture.
+        """
+        url = "https://github.com/"
+        status = 200
+        aioresponse.get(url, status=status)
+
+        async with http_session.get(url) as resp:
+            assert status == resp.status


### PR DESCRIPTION
fix: use WindowsSelectorEventLoopPolicy on windows


in addition, will use aioresponses for our test suite so no aiohttp sessions actually make real requests.